### PR TITLE
Update GalaxyGPT.cs

### DIFF
--- a/ketchupbot-discord/GalaxyGPT.cs
+++ b/ketchupbot-discord/GalaxyGPT.cs
@@ -126,10 +126,10 @@ public static class GalaxyGpt
                     .AppendLine();
 
             #region Response Answer
-            int _reducedMaxResponseLength;
+            int _reducedMaxResponseLength = _maxResponseLength;
             // If verbose, take off an additional 25% to account for the extra information
             if (verbose)
-                _reducedMaxResponseLength = (int)(_maxResponseLength * 0.75);
+                _reducedMaxResponseLength = (int)(_reducedMaxResponseLength * 0.75);
 
             if (apiResponse.Answer.Length > _reducedMaxResponseLength)
                 answerMessage.AppendLine(apiResponse.Answer[_reducedMaxResponseLength] +

--- a/ketchupbot-discord/GalaxyGPT.cs
+++ b/ketchupbot-discord/GalaxyGPT.cs
@@ -132,7 +132,7 @@ public static class GalaxyGpt
                 _reducedMaxResponseLength = (int)(_reducedMaxResponseLength * 0.75);
 
             if (apiResponse.Answer.Length > _reducedMaxResponseLength)
-                answerMessage.AppendLine(apiResponse.Answer[_reducedMaxResponseLength] +
+                answerMessage.AppendLine(apiResponse.Answer[.._reducedMaxResponseLength] +
                                          " (truncated)");
             else
                 answerMessage.AppendLine(apiResponse.Answer);

--- a/ketchupbot-discord/GalaxyGPT.cs
+++ b/ketchupbot-discord/GalaxyGPT.cs
@@ -126,13 +126,13 @@ public static class GalaxyGpt
                     .AppendLine();
 
             #region Response Answer
-
+            int _reducedMaxResponseLength;
             // If verbose, take off an additional 25% to account for the extra information
             if (verbose)
-                _maxResponseLength = (int)(_maxResponseLength * 0.75);
+                _reducedMaxResponseLength = (int)(_maxResponseLength * 0.75);
 
-            if (apiResponse.Answer.Length > _maxResponseLength)
-                answerMessage.AppendLine(apiResponse.Answer[..Math.Min(apiResponse.Answer.Length, _maxResponseLength)] +
+            if (apiResponse.Answer.Length > _reducedMaxResponseLength)
+                answerMessage.AppendLine(apiResponse.Answer[_reducedMaxResponseLength] +
                                          " (truncated)");
             else
                 answerMessage.AppendLine(apiResponse.Answer);


### PR DESCRIPTION
Fixed issue with lack of local variable use for conditional statement block evaluating API responses in verbose mode.
*Also fix redundant use of `Math.Min` at [Line 135](https://github.com/Galaxypedia-Wiki/ketchupbot-discord/blob/51661a88c21e55976315e14c8beb5014957d75d4/ketchupbot-discord/GalaxyGPT.cs#L135).